### PR TITLE
Server changes

### DIFF
--- a/JassServer/src/main/java/stats/StatsBufferListener.java
+++ b/JassServer/src/main/java/stats/StatsBufferListener.java
@@ -103,7 +103,6 @@ public class StatsBufferListener implements ChildEventListener {
                 stats = new UserStats(id);
             }
             stats.update(matchResult);
-            int newQuote = stats.lastQuote();
 
             updateUserStats(stats, stats.getPlayerId().toString());
         }

--- a/JassServer/src/main/java/stats/StatsBufferListener.java
+++ b/JassServer/src/main/java/stats/StatsBufferListener.java
@@ -103,7 +103,7 @@ public class StatsBufferListener implements ChildEventListener {
                 stats = new UserStats(id);
             }
             stats.update(matchResult);
-            int newQuote = stats.updateRank(new NaiveCalculator(stats));
+            int newQuote = stats.getLastQuote();
 
             refStats.child(dataSnapshot.getKey())
                     .setValue(stats);

--- a/JassServer/src/main/java/stats/StatsBufferListener.java
+++ b/JassServer/src/main/java/stats/StatsBufferListener.java
@@ -103,7 +103,7 @@ public class StatsBufferListener implements ChildEventListener {
                 stats = new UserStats(id);
             }
             stats.update(matchResult);
-            int newQuote = stats.getLastQuote();
+            int newQuote = stats.lastQuote();
 
             refStats.child(dataSnapshot.getKey())
                     .setValue(stats);

--- a/JassServer/src/main/java/stats/StatsBufferListener.java
+++ b/JassServer/src/main/java/stats/StatsBufferListener.java
@@ -105,14 +105,24 @@ public class StatsBufferListener implements ChildEventListener {
             stats.update(matchResult);
             int newQuote = stats.lastQuote();
 
-            refStats.child(dataSnapshot.getKey())
-                    .setValue(stats);
-            refPlayers.child(id.toString()).child("quote").setValue(newQuote);
+            updateUserStats(stats, stats.getPlayerId().toString());
         }
-
+        
         @Override
         public void onCancelled(DatabaseError databaseError) {
 
         }
+        
+        private void updateUserStats(UserStats stats, String id) {
+			refStats.child(id).child("playerId").setValue(stats.getPlayerId());
+			refStats.child(id).child("playedMatches").setValue(stats.getPlayedMatches());
+			refStats.child(id).child("wonMatches").setValue(stats.getWonMatches());
+			refStats.child(id).child("playedByDate").setValue(stats.getPlayedByDate());
+			refStats.child(id).child("wonByDate").setValue(stats.getWonByDate());
+			refStats.child(id).child("quoteByDate").setValue(stats.getQuoteByDate());
+			refStats.child(id).child("variants").setValue(stats.getVariants());
+			refStats.child(id).child("partners").setValue(stats.getPartners());
+			refStats.child(id).child("wonWith").setValue(stats.getWonWith());
+		}
     }
 }


### PR DESCRIPTION
Now the UserStats are updated field by field to prevent the server from overwriting the new rank value. This is not a very clean solution it is the simplest one. There is still a bug with the quoteByDate list which is not updated immediately (could not test tho).